### PR TITLE
Macros/Attributes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,95 @@
+# Contributing to DOML.net
+
+This document just layouts some specifications for contributing to this repository.
+
+## Issues/PRs
+
+Each PR should have a single purpose, i.e. fix a bug, or implement a single feature.  Some bugs may be grouped together if related but really each bug should have its own PR.  Opening an issue before each PR is standard procedure.
+
+Discussion about features should exist within the relevant issue (if there isn't one open a new one), rather than the PR itself; discussion about the implementation of the feature is for the PR.  Furthermore discussion about the feature in relation to the DOML spec i.e. disagreement about syntax should occur at the DOML repository rather then here, you can find it [here](https://github.com/DOML-Lang/DOML).
+
+## Style
+
+We follow the standard DOML style guide as detailed [here](https://github.com/DOML-Lang/DOML/blob/master/doml_styleguide.md).
+
+We have standardized on Microsoft's [C# Coding Conventions](https://msdn.microsoft.com/en-us/library/ff926074.aspx) and [General Naming Conventions](https://msdn.microsoft.com/en-us/library/ms229045(v=vs.110).aspx).  However we put braces on the same line as a compact style.
+
+As a TL;DR on our coding practices, adhere to the following example:
+
+```c#
+// All files begin with the following license header (remove this line):
+#region License
+// ====================================================
+// DOML Lang Copyright(C) 2018 DOML
+// This program comes with ABSOLUTELY NO WARRANTY; This is free software,
+// and you are welcome to redistribute it under certain conditions; See
+// file LICENSE, which is part of this source code package, for details.
+// ====================================================
+#endregion
+
+using System; // System usings go first
+using DOML.AST; // using's are sorted alphabetically
+using DOML.IR;
+
+// Use camelCasing unless stated otherwise.
+// Descriptive names for variables/methods should be used.
+// Fields, properties and methods should always specify their scope, aka private/protected/internal/public.
+
+// Interfaces start with an I and should use PascalCasing.
+public interface IInterfaceable {
+}
+
+// Class names should use PascalCasing.
+// Braces are on the same line
+
+/// <summary>
+/// Xml documentation comments are encouraged. Describe public APIs and the intent of code, not implementation details.
+/// </summary>
+public class Class {
+    // Private fields should be camelCased.
+    // Use properties for any field that needs access levels other than private
+    private string someField;
+
+    // Events should use PascalCasing as well.
+    // ✓ DO name events with a verb or a verb phrase.
+    // Examples include Clicked, Painting, DroppedDown, and so on.
+    // ✓ DO give events names with a concept of before and after, using the present and past tenses.
+    // For example, a close event that is raised before a window is closed would be called Closing,
+    // and one that is raised after the window is closed would be called Closed.
+    public event EventHandler<EventArgs> SomeEvent;
+
+    // Properties should use PascalCasing.
+    public int MemberProperty { get; set; }
+
+    // Methods should use PascalCasing.
+    // Method parameters should be camelCased.
+    public void SomeMethod(int functionParameter) {
+        // Local variables should also be camelCased.
+        int myLocalVariable = 0;
+        
+        // Compact brace style
+        if (x) {
+            // ..
+        } else if (y) {
+            // ..
+        } else {
+           // ..
+        }
+    }
+}
+```
+
+The only thing I will note: is to avoid the use of `var` as it often makes statements harder to read, for example the following should be avoided;
+```C#
+// No
+var x = 5;
+// Okay but would prefer `Dictionary<string, int> dict = new();` when that syntax is official
+var dict = new Dictionary<string, int>();
+// No
+foreach (var node in nodes) { ... }
+```
+While stylecop will allow it anywhere (except for cases where you can't see the type) I'll flag any cases where you do the first one, and may flag the second if it makes it harder to read.  I'll try not to be too pedantic though :).
+
+I'm quite happy to change the style guide for this project if enough people have valid criticisms :) and not just 'I prefer it this way'.
+
+It is also highly recommended that you install [StyleCop](https://github.com/TeamPorcupine/ProjectPorcupine/wiki/StyleCop), which will automatically point out any deviations from the project's style guidelines. Any deviations in your code which can be tracked by StyleCop will result in the rejection of your Pull Request.

--- a/DOML.net/DOML.net/Interpreter.cs
+++ b/DOML.net/DOML.net/Interpreter.cs
@@ -291,21 +291,14 @@ namespace DOML.IR {
                 #endregion
                 #region Map Instructions
                 case Opcodes.PUSH_MAP:
-                break;
                 case Opcodes.PUSH_COLLECTION:
-                break;
                 case Opcodes.SET_MAP:
-                break;
                 case Opcodes.SET_COLLECTION:
-                break;
                 case Opcodes.QUICK_SET_MAP:
-                break;
                 case Opcodes.ZIP_MAP:
-                break;
                 case Opcodes.GET_MAP:
-                break;
                 case Opcodes.GET_COLLECTION:
-                break;
+                throw new NotImplementedException("Maps aren't implemented");
                 #endregion
                 default:
                 throw new NotImplementedException("Option not implemented");

--- a/DOML.net/DOMLParser/AST.cs
+++ b/DOML.net/DOMLParser/AST.cs
@@ -217,22 +217,20 @@ namespace DOML.AST {
         }
     }
 
-    public class MacroNode : BaseNode {
-        public override void BasicCodegen(TextWriter writer, bool simple) {
-            throw new NotImplementedException();
-        }
+    public sealed class DummyNode : MacroNode {
+        public override void BasicCodegen(TextWriter writer, bool simple) { }
 
-        public override IEnumerable<Instruction> GetInstructions() {
-            throw new NotImplementedException();
-        }
+        public override IEnumerable<Instruction> GetInstructions() { yield return new Instruction(Opcodes.NOP, new object[0]); }
 
-        public override void Print(TextWriter writer, string indent) {
+        public override MacroNode ParseNode(TextReader reader, Parser parser) { return new DummyNode(); }
 
-        }
+        public override void Print(TextWriter writer, string indent) { }
 
-        public override bool Verify(TextWriter err) {
-            throw new NotImplementedException();
-        }
+        public override bool Verify(TextWriter err) { return true; }
+    }
+
+    public abstract class MacroNode : BaseNode {
+        public abstract MacroNode ParseNode(TextReader reader, Parser parser);
     }
 
     public sealed class ReserveNode : BaseNode {

--- a/DOML.net/DOMLParser/MacroClasses.cs
+++ b/DOML.net/DOMLParser/MacroClasses.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.IO;
+using DOML.IR;
+using System.Linq;
+
+namespace DOML.AST {
+    public sealed class IRMacroNode : MacroNode {
+        public List<Instruction> nodes = new List<Instruction>();
+
+        public override void BasicCodegen(TextWriter writer, bool simple) {
+            foreach (Instruction node in nodes) {
+                InstructionWriter.WriteInstructionOp(writer, (Opcodes)node.OpCode, simple);
+                foreach (object obj in node.Parameters) {
+                    writer.Write($" {obj}");
+                }
+                writer.WriteLine();
+            }
+        }
+
+        public override IEnumerable<Instruction> GetInstructions() {
+            foreach (Instruction node in nodes) {
+                yield return node;
+            }
+        }
+
+        public override MacroNode ParseNode(TextReader reader, Parser parser) {
+            // We need parsing IR to exist in parser first
+            throw new NotImplementedException();
+        }
+
+        public override void Print(TextWriter writer, string indent) {
+            writer.WriteLine("#IR");
+            // ? Do we want a better printout?? I'm just concerned it'll make it look noisy
+        }
+
+        public override bool Verify(TextWriter err) {
+            // ? Error maybe?
+            return true;
+        }
+    }
+
+    public sealed class DeinitMacroNode : MacroNode {
+        public override void BasicCodegen(TextWriter writer, bool simple) {
+            InstructionWriter.WriteInstructionOp(writer, Opcodes.DE_INIT, simple);
+            writer.WriteLine();
+        }
+
+        public override MacroNode ParseNode(TextReader reader, Parser parser) {
+            parser.IgnoreWhitespace(reader);
+            return new DeinitMacroNode();
+        }
+
+        public override IEnumerable<Instruction> GetInstructions() {
+            yield return new Instruction(Opcodes.DE_INIT, new object[0]);
+        }
+
+        public override void Print(TextWriter writer, string indent) {
+            writer.WriteLine("#deinit");
+        }
+
+        public override bool Verify(TextWriter err) {
+            return true;
+        }
+    }
+}

--- a/DOML.net/Test/Test.csproj
+++ b/DOML.net/Test/Test.csproj
@@ -36,10 +36,6 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Compile Remove="StaticBindings\StaticBinding-Test.UnitTests.Color.cs" />
     <Compile Remove="test.Designer.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="StaticBindings\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Implements #3 

## TODO

- [x] Implement parser support
- [x] Implement the standard attributes
    - [x] Version
    - [x] Deinit
    - [x] Strict
    - [x] NoKeywords

## What this PR doesn't do

- Implement IR, that is for another PR (#9)
- Allow users to define their own macros
    - While you can definitely do this, it doesn't give you any real helper functions and can be a bit of a pain to do, this is for another PR (#11).