### PR TITLE
Support definitions

### DIFF
--- a/DOML.net/Test/test.doml
+++ b/DOML.net/Test/test.doml
@@ -1,5 +1,7 @@
-﻿Test : Color {
-  RGB = 255, 64, 128, [1, 2, 3]
+﻿arr := [1, 2, 3]
+
+Test : Color {
+  RGB = 255, 64, 128, arr, arr
 }
 
 TheSame : Color::Normalized(r: 1.0, g: 0.25, b: 0.5) {


### PR DESCRIPTION
For #6 

Supports definitions like `x := 5` or `y := [1, 2, 3]`.  Doesn't support types yet.

## What this doesn't do

- Solve the issue of function calls
- Support types